### PR TITLE
Updates to match Dataverse PR #8891

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,37 @@
-# globus
+# dataverse-globus
 
 _In development_.
 
-A Dataverse external tool for globus integration to enable larger file uploads.
+A Dataverse tool for Globus integration to enable larger file uploads.
+
 # Local Installation 
 
-To register dataverse-globus in dataverse (local)
-
-`curl -X POST -H 'Content-type: application/json' --upload-file globus_upload.json http://localhost:8080/api/admin/externalTools` - for upload tool.
-
-`curl -X POST -H 'Content-type: application/json' --upload-file globus_download.json http://localhost:8080/api/admin/externalTools` - for download tool.
-
-where toolUrl should be the url of globus application. To run it on local machine one can use http://localhost/upload.
-
-Globus application should be registered in https://auth.globus.org/v2/web/developers It will get clientId.
-For development Redirect URI in globus registration should be http://localhost/*. Globus does not allow http, only htpps, except http://localhost and without port.
+The Globus application should be registered in https://auth.globus.org/v2/web/developers and will get a clientId.
+For development the Redirect URI in Globus registration should be http://localhost/*. Globus does not allow http, only https, except http://localhost and without a port.
 
 In ``src/assets/config.json`` the following fields should be filled:
 
-   *basicGlobusToken*  - Token of globus application which is  base64 encoded client ID and client credential (secret), separated by a single colon.
+   *basicGlobusToken*  - Token of Globus application which is a base64 encoded client ID and client credential (secret), separated by a single colon
    
-   *globusClientId*    - ClientId of registered globus application 
+   *globusClientId*    - ClientId of registered Globus application
    
    *globusEndpoint*    - Globus endpoint (S3 storage)
    
    *bucket*            - name of bucket in S3 storage
    
-   *apiToken*   - API token of Dataverse superuser. It is used for dataverse api for deleting Globus rules.
+   *apiToken*   - API token of Dataverse superuser. It is used for Dataverse API for deleting Globus rules
 
-To run dataverse-globus application one needs to install angular 9.
+To run the dataverse-globus application one needs to install Angular 9 using node (version 16+) and npm (version 7+).
 
 dataverse-globus was created using Angular CLI version 9.
 In order to generate node_modules run `npm install` from a root of project directory .
-For development purposes to run locally one can run dataverse-globus using
+Then run `npm install @angular/cli@9` to install `ng` and the rest of Angular CLI.
+The executable `ng` must be in your `$PATH`. To add it, run `export PATH=$PATH:node_modules/.bin`.
+
+For development purposes to run locally one can run dataverse-globus using...
 
 `sudo ng serve --port 80`
 
-this is because globus registration only allows for http://localhost/* for http.
+...this is because Globus registration only allows for http://localhost/* for http.
 
-
-
+It's normal for the home page of http://localhost to be blank but http://localhost/upload should show something.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5979,7 +5979,8 @@
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -71,7 +71,7 @@ export function load(http: HttpClient, config: ConfigService): (() => Promise<bo
             config.basicGlobusToken = x.basicGlobusToken;
             config.globusClientId = x.globusClientId;
             config.globusEndpoint = x.globusEndpoint;
-            config.bucket = x.bucket;
+            config.includeBucketInPath = x.includeBucketInPath;
             config.apiToken = x.apiToken;
             resolve(true);
           }),

--- a/src/app/config.service.ts
+++ b/src/app/config.service.ts
@@ -12,7 +12,7 @@ export class ConfigService {
   basicGlobusToken: string;
   globusClientId: string;
   globusEndpoint: string;
-  bucket: string;
+  includeBucketInPath: boolean;
   apiToken: string;
   constructor() { }
 }

--- a/src/app/interface/interface.component.ts
+++ b/src/app/interface/interface.component.ts
@@ -180,7 +180,9 @@ export class InterfaceComponent implements OnInit {
         console.log(this.transferData.datasetVersion);
         this.dvLocale = parameters[6];
         console.log(this.dvLocale);
-        this.transferData.datasetDirectory = '/' + this.transferData.datasetPid.substring(this.transferData.datasetPid.indexOf(':') + 1) + '/';
+        
+        this.transferData.datasetDirectory = this.config.includeBucketInPath ? this.transferData.storePrefix.substring(this.transferData.storePrefix.indexOf('://') + 3, this.transferData.storePrefix.length -4) : '/';
+        this.transferData.datasetDirectory = this.transferData.datasetDirectory + this.transferData.datasetPid.substring(this.transferData.datasetPid.indexOf(':') + 1) + '/';
         this.transferData.key = parameters[1];
     }
 

--- a/src/app/interface/interface.component.ts
+++ b/src/app/interface/interface.component.ts
@@ -181,7 +181,7 @@ export class InterfaceComponent implements OnInit {
         this.dvLocale = parameters[6];
         console.log(this.dvLocale);
         
-        this.transferData.datasetDirectory = this.config.includeBucketInPath ? this.transferData.storePrefix.substring(this.transferData.storePrefix.indexOf('://') + 3, this.transferData.storePrefix.length -4) : '/';
+        this.transferData.datasetDirectory = this.config.includeBucketInPath ? ('/' + this.transferData.storePrefix.substring(this.transferData.storePrefix.indexOf('://') + 3, this.transferData.storePrefix.length -1) + '/') : '/';
         this.transferData.datasetDirectory = this.transferData.datasetDirectory + this.transferData.datasetPid.substring(this.transferData.datasetPid.indexOf(':') + 1) + '/';
         this.transferData.key = parameters[1];
     }

--- a/src/app/interface/interface.component.ts
+++ b/src/app/interface/interface.component.ts
@@ -141,6 +141,7 @@ export class InterfaceComponent implements OnInit {
         this.dvLocale = this.globusService.getParameterByName('dvLocale');
         this.transferData.fileId = this.globusService.getParameterByName('fileId');
         this.transferData.fileMetadataId = this.globusService.getParameterByName('fileMetadataId');
+        this.transferData.storePrefix = this.globusService.getParameterByName('storePrefix');
         console.log(this.transferData.datasetVersion);
     }
     encodeStateDataset() {
@@ -149,6 +150,7 @@ export class InterfaceComponent implements OnInit {
             + this.transferData.siteUrl + '_'
             + this.transferData.datasetId + '_'
             + this.transferData.datasetVersion + '_'
+            + this.transferData.storePrefix + '_'
             + this.dvLocale); // encode
         return state;
     }
@@ -158,6 +160,7 @@ export class InterfaceComponent implements OnInit {
             + this.transferData.fileId + '_'
             + this.transferData.fileMetadataId + '_'
             + this.transferData.datasetVersion + '_'
+            + this.transferData.storePrefix + '_'
             + this.dvLocale); // encode
         return state;
     }
@@ -172,9 +175,10 @@ export class InterfaceComponent implements OnInit {
         console.log(this.transferData.siteUrl);
         this.transferData.datasetId = parameters[3];
         this.transferData.datasetVersion = parameters[4];
+        this.transferData.storePrefix = parameters[5];
         console.log(this.transferData.datasetId);
         console.log(this.transferData.datasetVersion);
-        this.dvLocale = parameters[5];
+        this.dvLocale = parameters[6];
         console.log(this.dvLocale);
         this.transferData.datasetDirectory = '/' + this.transferData.datasetPid.substring(this.transferData.datasetPid.indexOf(':') + 1) + '/';
         this.transferData.key = parameters[1];
@@ -194,7 +198,8 @@ export class InterfaceComponent implements OnInit {
         console.log(this.transferData.fileMetadataId);
         this.transferData.datasetVersion = parameters[4];
         console.log(this.transferData.datasetVersion);
-        this.dvLocale = parameters[5];
+        this.transferData.storePrefix = parameters[5];
+        this.dvLocale = parameters[6];
         console.log(this.dvLocale);
         this.transferData.key = parameters[0];
     }

--- a/src/app/navigate-template-download/navigate-template-download.component.ts
+++ b/src/app/navigate-template-download/navigate-template-download.component.ts
@@ -63,7 +63,8 @@ export class NavigateTemplateDownloadComponent implements OnInit, OnChanges {
 
 
   ngOnInit(): void {
-    this.startComponent();
+    // Not needed - ngOnChanges is called prior to ngOnInit
+    // this.startComponent();
   }
 
   ngOnChanges() {

--- a/src/app/navigate-template/navigate-template.component.ts
+++ b/src/app/navigate-template/navigate-template.component.ts
@@ -466,7 +466,7 @@ export class NavigateTemplateComponent implements OnInit, OnChanges {
       }
       file = file + '{ \"description\": \"\", \"directoryLabel\": \"' +
           this.listOfDirectoryLabels[i] + '\", \"restrict\": \"false\",' +
-          '\"storageIdentifier\":' + '\"s3://' + this.configService.bucket + ':' +
+          '\"storageIdentifier\":' + this.transferData.storePrefix
           this.listOfAllStorageIdentifiers[i] + '\",' +
           '\"fileName\":' + '\"' + this.listOfFileNames[i] + '\"'; // + ' }';
       file = file +  ' } ';

--- a/src/app/navigate-template/navigate-template.component.ts
+++ b/src/app/navigate-template/navigate-template.component.ts
@@ -466,7 +466,7 @@ export class NavigateTemplateComponent implements OnInit, OnChanges {
       }
       file = file + '{ \"description\": \"\", \"directoryLabel\": \"' +
           this.listOfDirectoryLabels[i] + '\", \"restrict\": \"false\",' +
-          '\"storageIdentifier\":' + this.transferData.storePrefix
+          '\"storageIdentifier\":\""' + this.transferData.storePrefix + 
           this.listOfAllStorageIdentifiers[i] + '\",' +
           '\"fileName\":' + '\"' + this.listOfFileNames[i] + '\"'; // + ' }';
       file = file +  ' } ';

--- a/src/app/navigate-template/navigate-template.component.ts
+++ b/src/app/navigate-template/navigate-template.component.ts
@@ -43,7 +43,8 @@ export class NavigateTemplateComponent implements OnInit, OnChanges {
   clientToken: any;
 
   ngOnInit(): void {
-    this.startComponent();
+    //Duplicates ngOnChange
+    ///this.startComponent();
   }
 
   ngOnChanges() {

--- a/src/app/navigate-template/navigate-template.component.ts
+++ b/src/app/navigate-template/navigate-template.component.ts
@@ -466,7 +466,7 @@ export class NavigateTemplateComponent implements OnInit, OnChanges {
       }
       file = file + '{ \"description\": \"\", \"directoryLabel\": \"' +
           this.listOfDirectoryLabels[i] + '\", \"restrict\": \"false\",' +
-          '\"storageIdentifier\":\""' + this.transferData.storePrefix + 
+          '\"storageIdentifier\":\"' + this.transferData.storePrefix + 
           this.listOfAllStorageIdentifiers[i] + '\",' +
           '\"fileName\":' + '\"' + this.listOfFileNames[i] + '\"'; // + ' }';
       file = file +  ' } ';

--- a/src/app/upload/upload.component.ts
+++ b/src/app/upload/upload.component.ts
@@ -14,6 +14,7 @@ export interface TransferData {
   siteUrl: string;
   fileId: string;
   fileMetadataId: string;
+  storePrefix: string;
 }
 
 @Component({

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -7,6 +7,6 @@
 	"basicGlobusToken": "", 
 	"globusClientId": "", 
 	"globusEndpoint": "", 
-	"bucket": "",
+	"includeBucketInPath": false,
         "apiToken": ""	
 }


### PR DESCRIPTION
These changes update the app to work with Dataverse ~5.12 with the matching updates in https://github.com/IQSS/dataverse/pull/8891. The main changes are 

- to use the dynamically supplied store/bucket info (rather than hardcoding s3 which worked when there was only one possible store as in Dataverse 4.x)
- to allow the bucket name to be added to paths (supporting a variation in Globus setup where the bucket is in the path)
- cleanup to remove some duplicate initialization.

I still need to verify that I don't have any further commits/that this still works with the latest Dataverse updates going into v5.12, etc. but hopefully this is about it.
