### PR TITLE
remove "new" from name of download tool

### DIFF
--- a/globus_download.json
+++ b/globus_download.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Globus download tool new",
+  "displayName": "Globus download tool",
   "description": "Download through Globus",
   "scope": "dataset",
   "type": "explore",


### PR DESCRIPTION
I'm assuming we don't want the word "new" in here.